### PR TITLE
Fix end-of-guide section

### DIFF
--- a/html/retry-timeout-guide.html
+++ b/html/retry-timeout-guide.html
@@ -3,6 +3,7 @@ layout: iguide-multipane
 title: "Failing fast and recovering from errors"
 description: Use MicroProfile's Timeout and Retry policies to fail fast and recover when running into failures.
 tags: ['Interactive', 'MicroProfile', 'Fault Tolerance', '@Retry', '@Timeout', 'microservices']
+categories: MicroProfile
 css:
 - interactive-guides/main
 - interactive-guides/step-content

--- a/html/retry-timeout-guide.html
+++ b/html/retry-timeout-guide.html
@@ -3,7 +3,6 @@ layout: iguide-multipane
 title: "Failing fast and recovering from errors"
 description: Use MicroProfile's Timeout and Retry policies to fail fast and recover when running into failures.
 tags: ['Interactive', 'MicroProfile', 'Fault Tolerance', '@Retry', '@Timeout', 'microservices']
-categories: MicroProfile
 css:
 - interactive-guides/main
 - interactive-guides/step-content

--- a/json-guides/retry-timeout.json
+++ b/json-guides/retry-timeout.json
@@ -881,9 +881,16 @@
             "name": "WhatNext",
             "title": "Great work!  You're done!",
             "description": [
-                "You learned about the benefits of the Microprofile Fault Tolerance feature Timeout and Retry policies and how to make your microservice more resilient to failures. You learned that the Timeout policy can be used to quickly fail requests that are hanging for too long. You learned to use the Retry policy to reattempt an operation that failed and to recover from the transient failures your application might experience.",
-                "<p> <a href='https://github.com/OpenLiberty/iguide-retry-timeout/tree/master/finish' >Download the sample retry timeout application bundled with Open Liberty on github</a>.</p>"
+                "You learned about the benefits of the Microprofile Fault Tolerance feature Timeout and Retry policies and how to make your microservice more resilient to failures. You learned that the Timeout policy can be used to quickly fail requests that are hanging for too long. You learned to use the Retry policy to reattempt an operation that failed and to recover from the transient failures your application might experience."
              ]
+        },
+        {
+            "name": "RelatedLinks",
+            "title": "Related links",
+            "description": ["Learn more about <b>MicroProfile</b>.",
+                            "<p> <a target='_blank' rel='noopener noreferrer' href='http://microprofile.io/' >See the MicroProfile specs.</a></p>",
+                            "<p> <a target='_blank' rel='noopener noreferrer' href='https://openliberty.io/docs/ref/microprofile/' >View MicroProfile API.</a></p>"
+                           ]
         }
     ]
 }


### PR DESCRIPTION
Remove link to sample application as it will automatically be created under 'Where to next'.

Set up links to MicroProfile specs and MicroProfile API.