### PR TITLE
Add a related guide to the retry-timeout guide

### DIFF
--- a/html/retry-timeout-guide.html
+++ b/html/retry-timeout-guide.html
@@ -5,6 +5,7 @@ seo-title: "Failing fast and recovering from errors"
 description: Use MicroProfile's Timeout and Retry policies to fail fast and recover when running into failures.
 seo-description: Use MicroProfile's Timeout and Retry policies to fail fast and recover when running into failures
 tags: ['Interactive', 'MicroProfile', 'Fault Tolerance', '@Retry', '@Timeout', 'microservices']
+categories: MicroProfile
 css:
 - interactive-guides/main
 - interactive-guides/step-content
@@ -44,6 +45,7 @@ js:
 - retry-timeout-guide
 - retry-timeout-playground
 duration: 20 minutes
+related-guides: ['circuit-breaker']
 releasedate: 2018-06-11
 guide-category: microprofile
 essential: false


### PR DESCRIPTION
In the end-of-guide section, add a related guide for the retry-timeout guide.  We picked to point to the circuit-breaker guide until directed to a tracks guide at some later time.

Updated retry-timeout-guide.html, putting in a 'categories' so this line
`Keep exploring MicroProfile with these guides.`
will show.  And added circuit-breaker as the related guide.