### PR TITLE
Allow default values in playground

### DIFF
--- a/js/retry-timeout-playground.js
+++ b/js/retry-timeout-playground.js
@@ -59,15 +59,14 @@ var retryTimeoutPlayground = function() {
                 // Retry guide steps use seconds for maxDuration, so convert to ms
                 if (this.stepName !== 'Playground') {
                     params.retryParms.maxDuration = params.retryParms.maxDuration*1000;
-                    params = this.verifyAndCorrectParams(params);
-                }
-
-                this.setParams(params);
-
-                //Below should be playground-only code
-                if (this.stepName === 'Playground') {
                     paramsValid = this.verifyAndCorrectParams(params);
                     if (paramsValid) {
+                        this.setParams(paramsValid);
+                    }
+                } else {
+                    paramsValid = this.verifyAndCorrectParams(params);
+                    if (paramsValid) {
+                        this.setParams(paramsValid);
                         this.editor.addCodeUpdated();
                         // Put the browser into focus.
                         var webBrowser = contentManager.getBrowser(this.stepName);


### PR DESCRIPTION
Default values were not being acknowledged in the Playground.

The problem was fixed in retry-timeout-playground.js.   Method setParams(), which sets the current parameters for the playground, was invoked before verifyAndCorrectParams(), which is the method that determines the default values if the inputted parameter is missing for the playground step only.  Therefore, the values being used were uncertain (NaN) if a parameter was not specified.

I corrected the logic in retry-timeout-playground.js.