### PR TITLE
Reset processing for the Retry-Timeout guide

### DIFF
--- a/js/retry-timeout-callback.js
+++ b/js/retry-timeout-callback.js
@@ -116,7 +116,7 @@ var retryTimeoutCallback = (function() {
         return match;
     };
 
-    var __checkMicroProfileFaultToleranceFeatureContent = function(content) {
+    var __checkMicroProfileFaultToleranceFeatureContent = function(editor, content) {
         var isFTFeatureThere = true;
         var editorContentBreakdown = __getMicroProfileFaultToleranceFeatureContent(content);
         if (editorContentBreakdown.hasOwnProperty("features")) {
@@ -129,18 +129,15 @@ var retryTimeoutCallback = (function() {
                 features = features.replace(/\s/g, '');
                 if (features.length !== "<feature>mpFaultTolerance-1.0</feature><feature>servlet-3.1</feature><feature>cdi-1.2</feature><feature>jaxrs-2.0</feature>".length) {
                     isFTFeatureThere = false; // contains extra text
-<<<<<<< Updated upstream
-=======
                 } else {
                     // Syntax is good.  Save off this version of server.xml.
                     utils.saveFeatureInContent(editor, content, "mpFaultTolerance-1.0");
->>>>>>> Stashed changes
                 }
             }
         } else {
             isFTFeatureThere = false;
         }
-        return isFTFeatureThere;
+        utils.handleEditorSave(editor.stepName, editor, isFTFeatureThere, __correctEditorError);
     };
 
     var __correctEditorError = function(stepName) {
@@ -172,8 +169,8 @@ var retryTimeoutCallback = (function() {
 
     var __saveServerXML = function(editor) {
         var stepName = stepContent.getCurrentStepName();
-        var content = contentManager.getTabbedEditorContents(stepName, serverFileName);        
-        utils.validateContentAndSave(stepName, editor, content, __checkMicroProfileFaultToleranceFeatureContent, __correctEditorError);
+        var content = contentManager.getTabbedEditorContents(stepName, serverFileName);
+        __checkMicroProfileFaultToleranceFeatureContent(editor, content);
     };
 
     var saveServerXMLButton = function(event) {
@@ -213,8 +210,14 @@ var retryTimeoutCallback = (function() {
         var contentIsCorrect = true;
         if (stepName === "TimeoutAnnotation") {
             contentIsCorrect = __validateEditorTimeoutAnnotationStep(content);
+            if (contentIsCorrect) {
+                __saveTimeoutAnnotationInContent(editor, content);
+            }
         } else if (stepName === "AddRetryOnRetry") {
             contentIsCorrect = __validateEditorRetryOnRetryStep(content);
+            if (contentIsCorrect) {
+                __saveRetryAnnotationInContent(editor, content);
+            } 
         } else if (stepName === "AddAbortOnRetry") {
             var paramsToCheck = ["retryOn=TimeoutException.class",
                                  "maxRetries=4",
@@ -227,6 +230,9 @@ var retryTimeoutCallback = (function() {
                                  "abortOn=FileNotFoundException.class"
                                 ]
             contentIsCorrect = __checkRetryAnnotationInContent(content, paramsToCheck);
+            if (contentIsCorrect) {
+                __saveRetryAnnotationInContent(editor, content);
+            }
         }
         utils.handleEditorSave(stepName, editor, contentIsCorrect, __correctEditorError, mapStepNameToScollLine[stepName], bankServiceFileName);
     };
@@ -635,6 +641,7 @@ var retryTimeoutCallback = (function() {
         var contentIsCorrect = false;
         if (__checkRetryAnnotationInContent(content, paramsToCheck)) {
             contentIsCorrect = true;
+            __saveRetryAnnotationInContent(editor, content);
         }
         utils.handleEditorSave(stepName, editor, contentIsCorrect, __correctEditorError, mapStepNameToScollLine[stepName], bankServiceFileName);
         return contentIsCorrect;

--- a/js/retry-timeout-callback.js
+++ b/js/retry-timeout-callback.js
@@ -129,6 +129,12 @@ var retryTimeoutCallback = (function() {
                 features = features.replace(/\s/g, '');
                 if (features.length !== "<feature>mpFaultTolerance-1.0</feature><feature>servlet-3.1</feature><feature>cdi-1.2</feature><feature>jaxrs-2.0</feature>".length) {
                     isFTFeatureThere = false; // contains extra text
+<<<<<<< Updated upstream
+=======
+                } else {
+                    // Syntax is good.  Save off this version of server.xml.
+                    utils.saveFeatureInContent(editor, content, "mpFaultTolerance-1.0");
+>>>>>>> Stashed changes
                 }
             }
         } else {
@@ -573,6 +579,19 @@ var retryTimeoutCallback = (function() {
 
         }
         return editorContents;
+    };
+
+    // Save the @Retry annotation as currently shown into the editor object.  This
+    // includes marking the correct lines for writable and read-only.
+    var __saveRetryAnnotationInContent = function(editor, content) {
+        utils.saveContentInEditor(editor, content, "@Retry\\s*(?:\\([^\\(\\)]*\\))");
+    };
+
+    // Save the @Timeout annotation as currently shown into the editor object.  This
+    // includes marking the correct lines for writable and read-only.
+    var __saveTimeoutAnnotationInContent = function(editor, content) {
+
+        utils.saveContentInEditor(editor, content, "@Timeout\\s*\\(\\s*2000\\s*\\)");
     };
 
     var createPlayground = function(root, stepName) {


### PR DESCRIPTION
In order for Reset to work correctly, we will save off the last successful (valid) save of the changes made to the editor widget, in all steps but the playground. The playground will always Reset to the original parameter values as seen on entry into the step.

Utilized the new method from commons utils.js file, `utils.saveFeatureInContent()`, to save the contents of the server.xml file after it has been verified.

Created methods `__saveTimeoutAnnotationInContent()` and `__saveRetryAnnotationInContent()` which will invoke the new method from commons utils.js file, `utils.saveContentInEditor()`, to save off validated editor content which can be used if Reset is selected.